### PR TITLE
Añadir gestión de artículos y modal de guardado de borrador

### DIFF
--- a/src/app/components/BudgetCalcTab.tsx
+++ b/src/app/components/BudgetCalcTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AddCircleIcon } from "@/assets/icons";
 import { InputText } from "@/ui/components";
 
@@ -8,13 +8,19 @@ interface Item {
   precio: number;
 }
 
-export const BudgetCalcTab = () => {
+interface BudgetCalcTabProps {
+  onItemsChange: (items: Item[]) => void;
+}
+
+export const BudgetCalcTab = ({ onItemsChange }: BudgetCalcTabProps) => {
   const [items, setItems] = useState<Item[]>([]);
   const [nombre, setNombre] = useState("");
   const [quantity, setQuantity] = useState("");
   const [precio, setPrecio] = useState("");
 
-  // Función para añadir un nuevo artículo
+  useEffect(() => {
+    onItemsChange(items);
+  }, [items, onItemsChange]);
   const handleAddItem = () => {
     if (nombre && quantity && precio) {
       const newItem: Item = {
@@ -23,23 +29,18 @@ export const BudgetCalcTab = () => {
         precio: parseFloat(precio),
       };
 
-      // Actualizar el estado con el nuevo artículo
       setItems([...items, newItem]);
-
-      // Limpiar los inputs
       setNombre("");
       setQuantity("");
       setPrecio("");
     }
   };
 
-  // Calcular el total global
   const totalGlobal = items.reduce(
     (total, item) => total + item.quantity * item.precio,
     0
   );
 
-  // Formatea los números como moneda en pesos argentinos
   const formatCurrency = (value: number): string => {
     return new Intl.NumberFormat("es-AR", {
       style: "currency",

--- a/src/app/components/BudgetContract.tsx
+++ b/src/app/components/BudgetContract.tsx
@@ -1,82 +1,110 @@
-import { Paper } from "@/ui/components/others/Paper"
-
-export const BudgetContract = () => {
-    const date = new Date() 
-    const today = date.getUTCDate() + '/' + date.getUTCMonth() + '/' + date.getUTCFullYear()
-    const datetimeExpiration = new Date( date.setMonth(date.getMonth() + 1));
-    const expirationDate = datetimeExpiration.getUTCDate() + '/' + datetimeExpiration.getUTCMonth() + '/' + datetimeExpiration.getUTCFullYear();
-   
-
-
-    return (
-        <Paper>
-            <div className="flex justify-between ">
-                <div>
-                    <h3 className="font-medium text-lg">Datos del cliente</h3>
-                    <p>{'nombre'}</p>
-                    <p>{'Direccion'}</p>
-                    <p>{'Provincia'} {'Pais'}</p>
-                    <p>{'Email'}</p>
-                </div>
-                <div>
-                    <h3 className="font-medium text-lg">Datos del emisor</h3>
-                    <p>{'nombre'}</p>
-                    <p>{'Direccion'}</p>
-                    <p>{'Provincia'} {'Pais'}</p>
-                    <p>{'Email'}</p>
-                </div>
-            </div>
-
-            <div className="mt-10 ">
-                <div className="mb-2">
-                    <h3 className="font-medium text-xl">Presupuesto</h3>
-
-                </div>
-                <div className="flex mb-8 justify-between">
-                    <p>N° de presupuesto: {'número'}</p>
-                    <p>Feha: {today}</p>
-                </div>
-            </div>
-            <div>
-                <p>Estimados/as Sres/Sras:</p>
-                <p>Le agradezco su consulta y le envio el siguiente presupuesto según lo conversado.</p>
-                <table className="mt-10 w-full  border-collapse *:border-2 ">
-                    <thead >
-                        <tr className="*:p-2 *:border-2">
-                            <th>Descripción</th>
-                            <th>Cantidad</th>
-                            <th>Precio/ud.</th>
-                            <th>Importe total</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr className="*:p-2 *:border-2 *:text-center">
-                            <td>
-                                Servicio
-                            </td>
-                            <td>
-                                1
-                            </td>
-                            <td>
-                                $200.000,00
-                            </td>
-                            <td>
-                                $200.000,00
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-
-                <hr className="mt-6 bg-black w-full h-1 mb-4 rounded-md" />
-
-                <div className="flex justify-between">
-                    <h4 className="uppercase text-xl font-medium">total <span>(Pesos)</span></h4>
-                    <h4 className="font-medium text-xl">{`$ 300.000,00`}</h4>
-                </div>
-                <div>
-                    <p>Esta oferta es válida hasta el [{ expirationDate.toString() }] </p>
-                </div>
-            </div>
-        </Paper>
-    )
+import { Paper } from "@/ui/components/others/Paper";
+interface Item {
+  nombre: string;
+  quantity: number;
+  precio: number;
 }
+
+interface BudgetContractProps {
+  budgetItems: Item[];
+}
+
+export const BudgetContract = ({ budgetItems }: BudgetContractProps) => {
+  const date = new Date();
+  const today =
+    date.getUTCDate() + "/" + date.getUTCMonth() + "/" + date.getUTCFullYear();
+  const datetimeExpiration = new Date(date.setMonth(date.getMonth() + 1));
+  const expirationDate =
+    datetimeExpiration.getUTCDate() +
+    "/" +
+    datetimeExpiration.getUTCMonth() +
+    "/" +
+    datetimeExpiration.getUTCFullYear();
+
+ 
+  const formatCurrency = (value: number): string => {
+    return new Intl.NumberFormat("es-AR", {
+      style: "currency",
+      currency: "ARS",
+    }).format(value);
+  };
+
+  const totalGlobal = budgetItems.reduce(
+    (total, item) => total + item.quantity * item.precio,
+    0
+  );
+
+  return (
+    <Paper>
+      <div className="flex justify-between ">
+        <div>
+          <h3 className="font-medium text-lg">Datos del cliente</h3>
+          <p>{"nombre"}</p>
+          <p>{"Direccion"}</p>
+          <p>
+            {"Provincia"} {"Pais"}
+          </p>
+          <p>{"Email"}</p>
+        </div>
+        <div>
+          <h3 className="font-medium text-lg">Datos del emisor</h3>
+          <p>{"nombre"}</p>
+          <p>{"Direccion"}</p>
+          <p>
+            {"Provincia"} {"Pais"}
+          </p>
+          <p>{"Email"}</p>
+        </div>
+      </div>
+
+      <div className="mt-10 ">
+        <div className="mb-2">
+          <h3 className="font-medium text-xl">Presupuesto</h3>
+        </div>
+        <div className="flex mb-8 justify-between">
+          <p>N° de presupuesto: {"número"}</p>
+          <p>Feha: {today}</p>
+        </div>
+      </div>
+      <div>
+        <p>Estimados/as Sres/Sras:</p>
+        <p>
+          Le agradezco su consulta y le envio el siguiente presupuesto según lo
+          conversado.
+        </p>
+        <table className="mt-10 w-full  border-collapse *:border-2 ">
+          <thead>
+            <tr className="*:p-2 *:border-2">
+              <th>Descripción</th>
+              <th>Cantidad</th>
+              <th>Precio/ud.</th>
+              <th>Importe total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {budgetItems.map((item, index) => (
+              <tr key={index}>
+                <td>{item.nombre}</td>
+                <td>{item.quantity}</td>
+                <td>{formatCurrency(item.precio)}</td>
+                <td>{formatCurrency(item.quantity * item.precio)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <hr className="mt-6 bg-black w-full h-1 mb-4 rounded-md" />
+
+        <div className="flex justify-between">
+          <h4 className="uppercase text-xl font-medium">
+            total <span>(Pesos)</span>
+          </h4>
+          <h4 className="font-medium text-xl">{formatCurrency(totalGlobal)}</h4>
+        </div>
+        <div>
+          <p>Esta oferta es válida hasta el [{expirationDate.toString()}] </p>
+        </div>
+      </div>
+    </Paper>
+  );
+};

--- a/src/app/components/BudgetViewDocumentTab.tsx
+++ b/src/app/components/BudgetViewDocumentTab.tsx
@@ -1,17 +1,25 @@
-import { Modal, OutlineButton } from "@/ui/components";
-import { BudgetContract } from "@/app/components";
+import { OutlineButton } from "@/ui/components";
 import { DownloadIcon, ShareIcon } from "@/assets/icons";
 import { FullScreenLoader } from "@/ui/components/spinner";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { BudgetContract } from "./BudgetContract";
 
-export const BudgetViewDocumentTab = () => {
+interface Item {
+  nombre: string;
+  quantity: number;
+  precio: number;
+}
+
+interface BudgetViewDocumentTabProps {
+  budgetItems: Item[];
+}
+
+export const BudgetViewDocumentTab = ({ budgetItems }: BudgetViewDocumentTabProps) => {
   const navigate = useNavigate();
-  const [showModal, setShowModal] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const handleSend = () => {
-    setShowModal(false);
     setLoading(true);
     setTimeout(() => {
       setLoading(false);
@@ -22,17 +30,11 @@ export const BudgetViewDocumentTab = () => {
   return (
     <div>
       <h3 className="font-medium">
-        Revisá el documento y envialo a tu cliente para confirmar el
-        presupuesto.
+        Revisá el documento y envialo a tu cliente para confirmar el presupuesto.
       </h3>
-      <BudgetContract />
+      <BudgetContract budgetItems={budgetItems} />
       <div className="flex items-center gap-4">
-        <OutlineButton
-          className=""
-          onClick={() => {
-            setShowModal(true);
-          }}
-        >
+        <OutlineButton className="" onClick={handleSend}>
           <ShareIcon />
           <span className="mx-3">Compartir</span>
         </OutlineButton>
@@ -40,31 +42,7 @@ export const BudgetViewDocumentTab = () => {
           <DownloadIcon />
           <span className="mx-3">Descargar</span>
         </OutlineButton>
-        <Modal
-          isOpen={showModal}
-          title="¿Listo para enviar este documento?"
-          onClose={() => setShowModal(false)}
-          footer={
-            <div className="flex gap-10">
-              <button
-                className="text-customOrange"
-                onClick={() => setShowModal(false)}
-              >
-                Cancelar
-              </button>
-              <button
-                className="text-customOrange"
-                onClick={handleSend}
-                disabled={loading}
-              >
-                Enviar
-              </button>
-            </div>
-          }
-          showCloseButton={false}
-        >
-          <p>Seguro quiere enviar el presupuesto de obra</p>
-        </Modal>
+
         <FullScreenLoader message="Enviando presupuesto" isVisible={loading} />
       </div>
     </div>

--- a/src/app/pages/budget/CreateBudgetPage.tsx
+++ b/src/app/pages/budget/CreateBudgetPage.tsx
@@ -4,57 +4,80 @@ import {
   BudgetViewDocumentTab,
 } from "@/app/components";
 import { ReturnLayout } from "@/layouts/ReturnLayout";
-import { ReusableButton } from "@/ui/components";
+import { Modal, ReusableButton } from "@/ui/components";
 import { useState, useTransition } from "react";
 import { useNavigate } from "react-router-dom";
+
+interface Item {
+  nombre: string;
+  quantity: number;
+  precio: number;
+}
 
 enum CreateBudgetTabs {
   Initial = 1,
   Payment = 2,
   End = 3,
 }
-const phases = [
-  {
-    phase: 1,
-    title: "Confirmá los datos",
-    component: <BudgetConfirmDataTab />,
-  },
-  {
-    phase: 2,
-    title: "Realizá el cálculo",
-    component: <BudgetCalcTab />,
-  },
-  {
-    phase: 3,
-    title: "¡Todo listo!",
-    component: <BudgetViewDocumentTab />,
-  },
-];
 
 export const CreateBudgetPage = () => {
   const navigate = useNavigate();
-  const [tab, setTab] = useState(
-    phases.find(phase => phase.phase == CreateBudgetTabs.Initial)!
-  );
+  const [showModal, setShowModal] = useState(false);
+  const [tab, setTab] = useState(CreateBudgetTabs.Initial);
+  const [budgetItems, setBudgetItems] = useState<Item[]>([]);
+
+  const phases = [
+    {
+      phase: CreateBudgetTabs.Initial,
+      title: "Confirmá los datos",
+      component: <BudgetConfirmDataTab />,
+    },
+    {
+      phase: CreateBudgetTabs.Payment,
+      title: "Realizá el cálculo",
+      component: (
+        <BudgetCalcTab
+          onItemsChange={(items: Item[]) => setBudgetItems(items)}
+        />
+      ),
+    },
+    {
+      phase: CreateBudgetTabs.End,
+      title: "¡Todo listo!",
+      component: <BudgetViewDocumentTab budgetItems={budgetItems} />,
+    },
+  ];
+
   const [isPending, startTransition] = useTransition();
 
   const handleChangeTab = () => {
-    if (tab.phase == CreateBudgetTabs.End) return;
-    startTransition(() => {
-      setTab(phases[tab.phase]);
-    });
+    if (tab === CreateBudgetTabs.End) return;
+
+    if (tab === CreateBudgetTabs.Payment) {
+      // Muestra el modal al intentar continuar desde la fase 2
+      setShowModal(true);
+    } else {
+      startTransition(() => {
+        setTab(tab + 1);
+      });
+    }
     if (isPending) return;
   };
+
   const handleGoBack = () => {
-    if (tab.phase === CreateBudgetTabs.Initial) {
-      startTransition(() => {
-        setTab(phases.find(phase => phase.phase == CreateBudgetTabs.Initial)!);
-        navigate(-1);
-      });
+    if (tab === CreateBudgetTabs.Initial) {
+      navigate(-1);
       return;
     }
     startTransition(() => {
-      setTab(phases.find(phase => phase.phase === tab.phase - 1)!);
+      setTab(tab - 1);
+    });
+  };
+
+  const handleConfirmContinue = () => {
+    setShowModal(false);
+    startTransition(() => {
+      setTab(tab + 1);
     });
   };
 
@@ -63,16 +86,42 @@ export const CreateBudgetPage = () => {
       returnFunction={() => handleGoBack()}
       title="Crear presupuesto"
     >
-      <div className="">
+      <div>
         <h4 className="font-medium text-customOrange text-xl mt-4 mb-2">
-          Paso {tab.phase}: {tab.title}
+          Paso {tab}: {phases[tab - 1].title}
         </h4>
-        {tab.component}
+        {phases[tab - 1].component}
       </div>
-      {tab.phase !== CreateBudgetTabs.End && (
+      {tab !== CreateBudgetTabs.End && (
         <ReusableButton onClick={handleChangeTab} className="mt-8">
           Continuar
         </ReusableButton>
+      )}
+      {showModal && (
+        <Modal
+          isOpen={showModal}
+          title="¿Guardar borrador?"
+          onClose={() => setShowModal(false)}
+          footer={
+            <div className="flex gap-10">
+              <button
+                className="text-customOrange"
+                onClick={() => setShowModal(false)}
+              >
+                Cancelar
+              </button>
+              <button
+                className="text-customOrange"
+                onClick={handleConfirmContinue}
+              >
+                Guardar
+              </button>
+            </div>
+          }
+          showCloseButton={false}
+        >
+          <p>Decide si guardar este cálculo como un borrador o eliminarlo</p>
+        </Modal>
       )}
     </ReturnLayout>
   );


### PR DESCRIPTION
- Añadido el prop `onItemsChange` en `BudgetCalcTab` para gestionar la actualización de artículos.
- Implementado `useEffect` en `BudgetCalcTab` para disparar `onItemsChange` cuando se actualiza la lista de artículos.
- Modificado `BudgetContract` para renderizar dinámicamente los artículos del presupuesto y calcular el total, incluyendo el formato de moneda.
- Refactorizado `BudgetViewDocumentTab` para aceptar y mostrar los artículos del presupuesto.
- Actualizada `CreateBudgetPage` para gestionar cambios de artículos entre fases, incluyendo el guardado de los artículos entre las pestañas.
- Añadido un modal para guardar un borrador en la fase 2 del proceso de creación de presupuesto.

